### PR TITLE
Montage now uses beta orbitals to build BetaMOs.tga

### DIFF
--- a/vmd_cube.py
+++ b/vmd_cube.py
@@ -402,7 +402,7 @@ def call_montage(options,cube_files):
                 sorted_set = []
                 for s in set:
                     s_split = s.split('_')
-                    sorted_set.append((int(s_split[2]),"Psi_a_%s_%s" % (s_split[2],s_split[3])))
+                    sorted_set.append((int(s_split[2]),"Psi_%s_%s_%s" % (s_split[1], s_split[2],s_split[3])))
                 sorted_set = sorted(sorted_set)
                 sorted_mos.append([s[1] for s in sorted_set])
            


### PR DESCRIPTION
I think the current version uses alpha orbitals to build both AlphaMOs.tga and BetaMOs.tga, this should correct that.
Thank you so much for this script, by the way! Very very convenient.